### PR TITLE
Feature: List app and services

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -1,0 +1,19 @@
+import json
+from abc import ABC
+
+
+class BaseModel(ABC):
+
+    def reload(self, items: dict):
+        if items is not None:
+            self.__dict__ = {k: items.get(k, v) for k, v in self.__dict__.items()}
+        return self
+
+    def serialize(self, pretty=True) -> str:
+        return json.dumps(self,
+                          default=lambda o: {p: getattr(o, p) for p in dir(o.__class__) if
+                                             isinstance(getattr(o.__class__, p), property)},
+                          indent=2 if pretty else None)
+
+    def to_property_dict(self):
+        return json.loads(self.serialize(pretty=False))

--- a/src/reverse_proxy_routes.py
+++ b/src/reverse_proxy_routes.py
@@ -16,8 +16,8 @@ def reverse_proxy_handler(url):
     url_prefixes = {}
     for installable_app in inheritors(InstallableApp):
         dummy_app = installable_app()
-        if dummy_app.gateway_access():
-            url_prefixes[dummy_app.url_prefix()] = dummy_app
+        if dummy_app.gateway_access:
+            url_prefixes[dummy_app.url_prefix] = dummy_app
     requested_url_prefix = "/{}".format(url_parts[0])
     if requested_url_prefix not in url_prefixes.keys():
         abort(404)

--- a/src/routes.py
+++ b/src/routes.py
@@ -3,7 +3,7 @@ from flask_restful import Api
 
 from src.platform.resource_wires_plat import WiresPlatResource
 from src.system.networking.network_info import NetworkInfo
-from src.system.resources.app.apps import AppResource
+from src.system.resources.app.app import AppResource
 from src.system.resources.app.delete_data import DeleteDataResource
 from src.system.resources.app.download import DownloadResource
 from src.system.resources.app.install import InstallResource
@@ -13,6 +13,7 @@ from src.system.resources.app.uninstall import UnInstallResource
 from src.system.resources.host_info import GetSystemMem, GetSystemTime, GetSystemDiscUsage
 from src.system.resources.ping import Ping
 from src.system.resources.service.command import SystemctlCommand
+from src.system.resources.service.service import ServiceResource
 from src.system.resources.service.status import SystemctlStatus
 from src.system.resources.service.status_bool import SystemctlStatusBool
 
@@ -31,6 +32,7 @@ api_system.add_resource(GetSystemDiscUsage, '/disc')
 api_system.add_resource(NetworkInfo, '/networking')
 
 api_service = Api(bp_service)
+api_service.add_resource(ServiceResource, "/")
 api_service.add_resource(SystemctlCommand, "/control")
 api_service.add_resource(SystemctlStatusBool, '/up/<string:service>')
 api_service.add_resource(SystemctlStatus, '/stats/<string:service>')

--- a/src/routes.py
+++ b/src/routes.py
@@ -3,6 +3,7 @@ from flask_restful import Api
 
 from src.platform.resource_wires_plat import WiresPlatResource
 from src.system.networking.network_info import NetworkInfo
+from src.system.resources.app.apps import AppResource
 from src.system.resources.app.delete_data import DeleteDataResource
 from src.system.resources.app.download import DownloadResource
 from src.system.resources.app.install import InstallResource
@@ -36,6 +37,7 @@ api_service.add_resource(SystemctlStatus, '/stats/<string:service>')
 
 # 3
 api_app = Api(bp_app)
+api_app.add_resource(AppResource, '/')
 api_app.add_resource(ReleaseResource, '/releases/<string:service>')
 api_app.add_resource(DownloadResource, '/download')
 api_app.add_resource(InstallResource, '/install')

--- a/src/setting.py
+++ b/src/setting.py
@@ -23,6 +23,8 @@ class AppSetting:
                                              os.path.join(self.global_dir, self.default_data_dir))
         self.__artifact_dir = self.__compute_dir(kwargs.get('artifact_dir'),
                                                  os.path.join(self.data_dir, self.default_artifact_dir))
+        self.__download_dir = self.__compute_dir('', os.path.join(self.__artifact_dir, 'download'))
+        self.__install_dir = self.__compute_dir('', os.path.join(self.__artifact_dir, 'install'))
         self.__token = '' if not kwargs.get('token') else kwargs.get('token')
         self.__token_file = os.path.join(self.data_dir, self.default_token_file)
         self.__prod = kwargs.get('prod') or False
@@ -39,6 +41,14 @@ class AppSetting:
     @property
     def artifact_dir(self) -> str:
         return self.__artifact_dir
+
+    @property
+    def download_dir(self) -> str:
+        return self.__download_dir
+
+    @property
+    def install_dir(self) -> str:
+        return self.__install_dir
 
     @property
     def token(self) -> str:

--- a/src/system/apps/bacnet_server_app.py
+++ b/src/system/apps/bacnet_server_app.py
@@ -4,6 +4,7 @@ from src.system.apps.base.python_app import PythonApp
 class BACnetServerApp(PythonApp):
     def __init__(self):
         super(BACnetServerApp, self).__init__(
+            display_name='Rubix BACnet Server',
             repo_name='rubix-bacnet-server',
             service_file_name='nubeio-bacnet-server.service',
             data_dir_name='bacnet-server',
@@ -15,5 +16,5 @@ class BACnetServerApp(PythonApp):
         )
 
     @classmethod
-    def id(cls) -> str:
+    def service(cls) -> str:
         return 'BACNET_SERVER'

--- a/src/system/apps/bacnet_server_app.py
+++ b/src/system/apps/bacnet_server_app.py
@@ -2,27 +2,18 @@ from src.system.apps.base.python_app import PythonApp
 
 
 class BACnetServerApp(PythonApp):
+    def __init__(self):
+        super(BACnetServerApp, self).__init__(
+            repo_name='rubix-bacnet-server',
+            service_file_name='nubeio-bacnet-server.service',
+            data_dir_name='bacnet-server',
+            port=1717,
+            min_support_version='v1.3.0',
+            description='Flask Application for Nube BACNET SERVER',
+            gateway_access=True,
+            url_prefix='/bacnet',
+        )
+
     @classmethod
     def id(cls) -> str:
         return 'BACNET_SERVER'
-
-    def name(self) -> str:
-        return 'rubix-bacnet-server'
-
-    def service_file_name(self) -> str:
-        return 'nubeio-bacnet-server.service'
-
-    def data_dir_name(self) -> str:
-        return 'bacnet-server'
-
-    def description(self) -> str:
-        return 'Flask Application for Nube BACNET SERVER'
-
-    def port(self) -> int:
-        return 1717
-
-    def url_prefix(self) -> str:
-        return '/bacnet'
-
-    def min_support_version(self) -> str:
-        return 'v1.3.0'

--- a/src/system/apps/base/frontend_app.py
+++ b/src/system/apps/base/frontend_app.py
@@ -4,13 +4,17 @@ from src.system.apps.base.installable_app import InstallableApp
 
 
 class FrontendApp(InstallableApp, ABC):
+    @property
+    def app_type(self):
+        return "FrontendApp"
+
     def get_download_link(self) -> str:
-        return 'https://api.github.com/repos/NubeIO/{}/zipball/{}'.format(self.name(), self.version)
+        return 'https://api.github.com/repos/NubeIO/{}/zipball/{}'.format(self.repo_name, self.__version)
 
     def get_install_cmd(self) -> str:
         # TODO: remove user and upgrade parameters in future
         return "sudo bash script.bash start -service_name={} -u={} -dir={} -data_dir={} -p={}".format(
-            self.service_file_name(), 'root', self.get_wd(), self.get_data_dir(), self.port())
+            self.service_file_name, 'root', self.get_wd(), self.get_data_dir(), self.port)
 
     @staticmethod
     def get_delete_command() -> str:

--- a/src/system/apps/base/frontend_app.py
+++ b/src/system/apps/base/frontend_app.py
@@ -9,7 +9,7 @@ class FrontendApp(InstallableApp, ABC):
         return "FrontendApp"
 
     def get_download_link(self) -> str:
-        return 'https://api.github.com/repos/NubeIO/{}/zipball/{}'.format(self.repo_name, self.__version)
+        return 'https://api.github.com/repos/NubeIO/{}/zipball/{}'.format(self.repo_name, self.version())
 
     def get_install_cmd(self) -> str:
         # TODO: remove user and upgrade parameters in future

--- a/src/system/apps/base/installable_app.py
+++ b/src/system/apps/base/installable_app.py
@@ -31,7 +31,7 @@ class InstallableApp(BaseModel, ABC):
         for subclass in inheritors(InstallableApp):
             if subclass.id() == service:
                 instance = subclass()
-                instance.version = version
+                instance.__version = version
                 return instance
         raise ModuleNotFoundError("service {} does not exist in our system".format(service))
 
@@ -91,6 +91,9 @@ class InstallableApp(BaseModel, ABC):
     def get_releases_link(self) -> str:
         return 'https://api.github.com/repos/NubeIO/{}/releases'.format(self.repo_name)
 
+    def get_selected_releases_link(self) -> str:
+        return 'https://api.github.com/repos/NubeIO/{}/releases/tags/{}'.format(self.repo_name, self.__version)
+
     def get_download_link(self) -> str:
         raise NotImplementedError("get_download_link logic needs to be overridden")
 
@@ -104,11 +107,11 @@ class InstallableApp(BaseModel, ABC):
 
     def get_download_dir(self) -> str:
         setting = current_app.config[AppSetting.KEY]
-        return os.path.join(setting.artifact_dir, 'download', self.repo_name)
+        return os.path.join(setting.download_dir, self.repo_name)
 
     def get_installation_dir(self) -> str:
         setting = current_app.config[AppSetting.KEY]
-        return os.path.join(setting.artifact_dir, 'install', self.repo_name)
+        return os.path.join(setting.install_dir, self.repo_name)
 
     def get_downloaded_dir(self):
         return os.path.join(self.get_download_dir(), self.__version)

--- a/src/system/apps/base/python_app.py
+++ b/src/system/apps/base/python_app.py
@@ -9,6 +9,10 @@ from src.system.apps.base.installable_app import InstallableApp
 
 
 class PythonApp(InstallableApp, ABC):
+    @property
+    def app_type(self):
+        return "PythonApp"
+
     def get_download_link(self) -> str:
         resp = requests.get(self.get_releases_link())
         data = json.loads(resp.content)

--- a/src/system/apps/base/python_app.py
+++ b/src/system/apps/base/python_app.py
@@ -14,10 +14,11 @@ class PythonApp(InstallableApp, ABC):
         return "PythonApp"
 
     def get_download_link(self) -> str:
-        resp = requests.get(self.get_selected_releases_link())
+        release_link = 'https://api.github.com/repos/NubeIO/{}/releases/tags/{}'.format(self.repo_name, self.version())
+        resp = requests.get(release_link)
         row = json.loads(resp.content)
         setting = current_app.config[AppSetting.KEY]
         for asset in row.get('assets', []):
             if setting.device_type in asset.get('browser_download_url'):
                 return asset.get('browser_download_url')
-        raise ModuleNotFoundError('No app for type {} & version {}'.format(setting.device_type, self.__version))
+        raise ModuleNotFoundError('No app for type {} & version {}'.format(setting.device_type, self.version()))

--- a/src/system/apps/base/python_app.py
+++ b/src/system/apps/base/python_app.py
@@ -14,11 +14,10 @@ class PythonApp(InstallableApp, ABC):
         return "PythonApp"
 
     def get_download_link(self) -> str:
-        resp = requests.get(self.get_releases_link())
-        data = json.loads(resp.content)
-        for row in data:
-            for asset in row.get('assets', []):
-                setting = current_app.config[AppSetting.KEY]
-                if setting.device_type in asset.get('browser_download_url'):
-                    return asset.get('browser_download_url')
-        return ""
+        resp = requests.get(self.get_selected_releases_link())
+        row = json.loads(resp.content)
+        setting = current_app.config[AppSetting.KEY]
+        for asset in row.get('assets', []):
+            if setting.device_type in asset.get('browser_download_url'):
+                return asset.get('browser_download_url')
+        raise ModuleNotFoundError('No app for type {} & version {}'.format(setting.device_type, self.__version))

--- a/src/system/apps/lora_raw_app.py
+++ b/src/system/apps/lora_raw_app.py
@@ -2,27 +2,18 @@ from src.system.apps.base.python_app import PythonApp
 
 
 class LoRaRawApp(PythonApp):
+    def __init__(self):
+        super(LoRaRawApp, self).__init__(
+            repo_name='lora-raw',
+            service_file_name='nubeio-lora-raw.service',
+            data_dir_name='lora-raw',
+            port=1919,
+            min_support_version='v1.1.0',
+            description='NubeIO LoRa Raw pyserial',
+            gateway_access=True,
+            url_prefix='/lora',
+        )
+
     @classmethod
     def id(cls) -> str:
         return 'LORA_RAW'
-
-    def name(self) -> str:
-        return 'lora-raw'
-
-    def service_file_name(self) -> str:
-        return 'nubeio-lora-raw.service'
-
-    def data_dir_name(self) -> str:
-        return 'lora-raw'
-
-    def description(self) -> str:
-        return 'NubeIO LoRa Raw pyserial'
-
-    def port(self) -> int:
-        return 1919
-
-    def url_prefix(self) -> str:
-        return '/lora'
-
-    def min_support_version(self) -> str:
-        return 'v1.1.0'

--- a/src/system/apps/lora_raw_app.py
+++ b/src/system/apps/lora_raw_app.py
@@ -4,6 +4,7 @@ from src.system.apps.base.python_app import PythonApp
 class LoRaRawApp(PythonApp):
     def __init__(self):
         super(LoRaRawApp, self).__init__(
+            display_name='LoRa Raw',
             repo_name='lora-raw',
             service_file_name='nubeio-lora-raw.service',
             data_dir_name='lora-raw',
@@ -15,5 +16,5 @@ class LoRaRawApp(PythonApp):
         )
 
     @classmethod
-    def id(cls) -> str:
+    def service(cls) -> str:
         return 'LORA_RAW'

--- a/src/system/apps/point_server_app.py
+++ b/src/system/apps/point_server_app.py
@@ -4,6 +4,7 @@ from src.system.apps.base.python_app import PythonApp
 class PointServerApp(PythonApp):
     def __init__(self):
         super(PointServerApp, self).__init__(
+            display_name='Rubix Point Server',
             repo_name='rubix-point-server',
             service_file_name='nubeio-point-server.service',
             data_dir_name='point-server',
@@ -15,5 +16,5 @@ class PointServerApp(PythonApp):
         )
 
     @classmethod
-    def id(cls) -> str:
+    def service(cls) -> str:
         return 'POINT_SERVER'

--- a/src/system/apps/point_server_app.py
+++ b/src/system/apps/point_server_app.py
@@ -2,27 +2,18 @@ from src.system.apps.base.python_app import PythonApp
 
 
 class PointServerApp(PythonApp):
+    def __init__(self):
+        super(PointServerApp, self).__init__(
+            repo_name='rubix-point-server',
+            service_file_name='nubeio-point-server.service',
+            data_dir_name='point-server',
+            port=1515,
+            min_support_version='v1.2.0',
+            description='Flask Application for Nube Rest API',
+            gateway_access=True,
+            url_prefix='/ps',
+        )
+
     @classmethod
     def id(cls) -> str:
         return 'POINT_SERVER'
-
-    def name(self) -> str:
-        return 'rubix-point-server'
-
-    def service_file_name(self) -> str:
-        return 'nubeio-point-server.service'
-
-    def data_dir_name(self) -> str:
-        return 'point-server'
-
-    def description(self) -> str:
-        return 'Flask Application for Nube Rest API'
-
-    def port(self) -> int:
-        return 1515
-
-    def url_prefix(self) -> str:
-        return '/ps'
-
-    def min_support_version(self) -> str:
-        return 'v1.2.0'

--- a/src/system/apps/rubix_plat_build_app.py
+++ b/src/system/apps/rubix_plat_build_app.py
@@ -6,6 +6,7 @@ from src.system.apps.base.frontend_app import FrontendApp
 class RubixPlatBuildApp(FrontendApp):
     def __init__(self):
         super(RubixPlatBuildApp, self).__init__(
+            display_name='Rubix Plat',
             repo_name='rubix-plat-build',
             service_file_name='nubeio-wires-plat.service',
             data_dir_name='rubix-plat-build',
@@ -14,7 +15,7 @@ class RubixPlatBuildApp(FrontendApp):
         )
 
     @classmethod
-    def id(cls) -> str:
+    def service(cls) -> str:
         return 'RUBIX_PLAT'
 
     def get_cwd(self) -> str:

--- a/src/system/apps/rubix_plat_build_app.py
+++ b/src/system/apps/rubix_plat_build_app.py
@@ -4,27 +4,18 @@ from src.system.apps.base.frontend_app import FrontendApp
 
 
 class RubixPlatBuildApp(FrontendApp):
+    def __init__(self):
+        super(RubixPlatBuildApp, self).__init__(
+            repo_name='rubix-plat-build',
+            service_file_name='nubeio-wires-plat.service',
+            data_dir_name='rubix-plat-build',
+            port=1414,
+            min_support_version='v1.1.6'
+        )
+
     @classmethod
     def id(cls) -> str:
         return 'RUBIX_PLAT'
-
-    def name(self) -> str:
-        return 'rubix-plat-build'
-
-    def service_file_name(self) -> str:
-        return 'rubix'
-
-    def data_dir_name(self) -> str:
-        return 'rubix-plat-build'
-
-    def port(self) -> int:
-        return 1414
-
-    def min_support_version(self) -> str:
-        return 'v1.1.6'
-
-    def gateway_access(self) -> bool:
-        return False
 
     def get_cwd(self) -> str:
         return os.path.join(super().get_cwd(), 'rubix-plat')

--- a/src/system/apps/wires_builds_app.py
+++ b/src/system/apps/wires_builds_app.py
@@ -4,27 +4,18 @@ from src.system.apps.base.frontend_app import FrontendApp
 
 
 class WiresBuildsApp(FrontendApp):
+    def __init__(self):
+        super(WiresBuildsApp, self).__init__(
+            repo_name='wires-builds',
+            service_file_name='nubeio-rubix-wires.service',
+            data_dir_name='rubix-wires',
+            port=1313,
+            min_support_version='v1.8.7'
+        )
+
     @classmethod
     def id(cls) -> str:
         return 'WIRES'
-
-    def name(self) -> str:
-        return 'wires-builds'
-
-    def service_file_name(self) -> str:
-        return 'nubeio-rubix-wires.service'
-
-    def data_dir_name(self) -> str:
-        return 'rubix-wires'
-
-    def port(self) -> int:
-        return 1313
-
-    def min_support_version(self) -> str:
-        return 'v1.8.7'
-
-    def gateway_access(self) -> bool:
-        return False
 
     def get_cwd(self) -> str:
         return os.path.join(super().get_cwd(), 'rubix-wires/systemd')

--- a/src/system/apps/wires_builds_app.py
+++ b/src/system/apps/wires_builds_app.py
@@ -6,6 +6,7 @@ from src.system.apps.base.frontend_app import FrontendApp
 class WiresBuildsApp(FrontendApp):
     def __init__(self):
         super(WiresBuildsApp, self).__init__(
+            display_name='Rubix Wires',
             repo_name='wires-builds',
             service_file_name='nubeio-rubix-wires.service',
             data_dir_name='rubix-wires',
@@ -14,7 +15,7 @@ class WiresBuildsApp(FrontendApp):
         )
 
     @classmethod
-    def id(cls) -> str:
+    def service(cls) -> str:
         return 'WIRES'
 
     def get_cwd(self) -> str:

--- a/src/system/resources/app/app.py
+++ b/src/system/resources/app/app.py
@@ -4,7 +4,7 @@ from src.inheritors import inheritors
 from src.system.apps.base.installable_app import InstallableApp
 
 
-class AppsResource(Resource):
+class AppResource(Resource):
     @classmethod
     def get(cls):
         apps = []

--- a/src/system/resources/app/app.py
+++ b/src/system/resources/app/app.py
@@ -11,6 +11,6 @@ class AppResource(Resource):
         for subclass in inheritors(InstallableApp):
             instance = subclass()
             app = instance.to_property_dict()
-            app['service'] = instance.id()
+            app['service'] = instance.service()
             apps.append(app)
         return apps

--- a/src/system/resources/app/apps.py
+++ b/src/system/resources/app/apps.py
@@ -1,0 +1,16 @@
+from flask_restful import Resource
+
+from src.inheritors import inheritors
+from src.system.apps.base.installable_app import InstallableApp
+
+
+class AppsResource(Resource):
+    @classmethod
+    def get(cls):
+        apps = []
+        for subclass in inheritors(InstallableApp):
+            instance = subclass()
+            app = instance.to_property_dict()
+            app['service'] = instance.id()
+            apps.append(app)
+        return apps

--- a/src/system/resources/app/download.py
+++ b/src/system/resources/app/download.py
@@ -30,10 +30,11 @@ class DownloadResource(Resource):
             if isinstance(app, PythonApp):
                 # enforcing to extract on version directory
                 dir_with_version = os.path.join(download_dir, version)
-                os.mkdir(dir_with_version)
+                mode = 0o744
+                os.makedirs(dir_with_version, mode, True)
                 app_file = os.path.join(dir_with_version, 'app')
                 os.rename(extracted_dir, app_file)
-                os.chmod(app_file, 0o744)
+                os.chmod(app_file, mode)
             else:
                 # they are already wrapped on folder
                 os.rename(extracted_dir, downloaded_dir)

--- a/src/system/resources/app/install.py
+++ b/src/system/resources/app/install.py
@@ -26,8 +26,8 @@ class InstallResource(Resource):
         shutil.copytree(app.get_downloaded_dir(), app.get_installed_dir())
         installation = False
         if isinstance(app, PythonApp):
-            systemd = AppSystemd(app.service_file_name(), app.get_wd(), app.port(), app.get_data_dir(), app.name(),
-                                 app.description())
+            systemd = AppSystemd(app.service_file_name, app.get_wd(), app.port, app.get_data_dir(), app.repo_name,
+                                 app.description)
             installation = systemd.install()
         elif isinstance(app, FrontendApp):
             installation = execute_command(app.get_install_cmd(), app.get_cwd())

--- a/src/system/resources/app/release.py
+++ b/src/system/resources/app/release.py
@@ -15,6 +15,6 @@ class ReleaseResource(Resource):
         data = json.loads(resp.content)
         releases = []
         for row in data:
-            if version.parse(app.min_support_version()) <= version.parse(row.get('tag_name')):
+            if version.parse(app.min_support_version) <= version.parse(row.get('tag_name')):
                 releases.append(row.get('tag_name'))
         return releases

--- a/src/system/resources/app/status.py
+++ b/src/system/resources/app/status.py
@@ -13,6 +13,6 @@ class StatusResource(Resource):
             dummy_app = installable_app()
             version = get_extracted_dir(dummy_app.get_installation_dir())
             if version:
-                status = systemctl_status(dummy_app.service_file_name())
+                status = systemctl_status(dummy_app.service_file_name)
                 installed_apps.append({'version': version.split("/")[-1], **status})
         return installed_apps

--- a/src/system/resources/app/uninstall.py
+++ b/src/system/resources/app/uninstall.py
@@ -20,7 +20,7 @@ class UnInstallResource(Resource):
             abort(404, message="service {} is not running".format(service))
         deletion = False
         if isinstance(app, PythonApp):
-            app_creator = AppSystemd(app.service_file_name())
+            app_creator = AppSystemd(app.service_file_name)
             deletion = app_creator.uninstall()
         elif isinstance(app, FrontendApp):
             deletion = execute_command(FrontendApp.get_delete_command(), app.get_cwd())

--- a/src/system/resources/app/utils.py
+++ b/src/system/resources/app/utils.py
@@ -7,8 +7,8 @@ from src.system.apps.base.installable_app import InstallableApp
 def get_app_from_service(service, version_=''):
     try:
         app = InstallableApp.get_app(service, version_)
-        if not version_ or version.parse(app.min_support_version()) <= version.parse(version_):
+        if not version_ or version.parse(app.min_support_version) <= version.parse(version_):
             return app
-        abort(400, message='Your version need to be version <= {}'.format(app.min_support_version()))
+        abort(400, message='Your version need to be version <= {}'.format(app.min_support_version))
     except ModuleNotFoundError as e:
         abort(404, message=str(e))

--- a/src/system/resources/service/service.py
+++ b/src/system/resources/service/service.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource
+from flask_restful import Resource, marshal_with, fields
 
 from src.inheritors import inheritors
 from src.system.apps.base.installable_app import InstallableApp
@@ -6,9 +6,17 @@ from src.system.resources.service.utils import Services
 
 
 class ServiceResource(Resource):
+    fields = {
+        'display_name': fields.String,
+        'service': fields.String,
+    }
+
     @classmethod
+    @marshal_with(fields)
     def get(cls):
-        services = list(Services.__members__.keys())
+        services = []
+        for service in Services.__members__.keys():
+            services.append({'display_name': Services[service].value.get('display_name'), 'service': service})
         for subclass in inheritors(InstallableApp):
-            services.append(subclass.id())
+            services.append({'display_name': subclass().display_name, 'service': subclass.service()})
         return services

--- a/src/system/resources/service/service.py
+++ b/src/system/resources/service/service.py
@@ -1,0 +1,14 @@
+from flask_restful import Resource
+
+from src.inheritors import inheritors
+from src.system.apps.base.installable_app import InstallableApp
+from src.system.resources.service.utils import Services
+
+
+class ServiceResource(Resource):
+    @classmethod
+    def get(cls):
+        services = list(Services.__members__.keys())
+        for subclass in inheritors(InstallableApp):
+            services.append(subclass.id())
+        return services

--- a/src/system/resources/service/utils.py
+++ b/src/system/resources/service/utils.py
@@ -6,10 +6,10 @@ from src.system.apps.base.installable_app import InstallableApp
 
 
 class Services(enum.Enum):
-    LORAWAN = 'lorawan-server.service'
-    MOSQUITTO = 'mosquitto.service'
-    BBB = 'nubeio-bbio.service'
-    DRAC = 'nubeio-drac.service'
+    LORAWAN = {'service_file_name': 'lorawan-server.service', 'display_name': 'LoRa WAN Server Service'}
+    MOSQUITTO = {'service_file_name': 'mosquitto.service', 'display_name': 'Mosquitto Service'}
+    BBB = {'service_file_name': 'nubeio-bbio.service', 'display_name': 'BBB IO Service'}
+    DRAC = {'service_file_name': 'nubeio-drac.service', 'display_name': 'DRAC Server Service'}
 
 
 class ServiceAction(enum.Enum):
@@ -22,7 +22,7 @@ class ServiceAction(enum.Enum):
 
 def validate_service(service) -> str:
     if service in Services.__members__.keys():
-        return Services[service].value
+        return Services[service].value.get('service_file_name')
     try:
         app = InstallableApp.get_app(service, "")
         return app.service_file_name()


### PR DESCRIPTION
## Summary:

#### List Apps for installation: `/api/app/`

Output example:
```json
[
  {
    "app_type": "FrontendApp",
    "data_dir_name": "rubix-wires",
    "description": "",
    "display_name": "Rubix Wires",
    "gateway_access": false,
    "min_support_version": "v1.8.7",
    "port": 1313,
    "repo_name": "wires-builds",
    "service_file_name": "nubeio-rubix-wires.service",
    "url_prefix": "",
    "service": "WIRES"
  },
  {
    "app_type": "PythonApp",
    "data_dir_name": "point-server",
    "description": "Flask Application for Nube Rest API",
    "display_name": "Rubix Point Server",
    "gateway_access": true,
    "min_support_version": "v1.2.0",
    "port": 1515,
    "repo_name": "rubix-point-server",
    "service_file_name": "nubeio-point-server.service",
    "url_prefix": "/ps",
    "service": "POINT_SERVER"
  },
  {
    "app_type": "FrontendApp",
    "data_dir_name": "rubix-plat-build",
    "description": "",
    "display_name": "Rubix Plat",
    "gateway_access": false,
    "min_support_version": "v1.1.6",
    "port": 1414,
    "repo_name": "rubix-plat-build",
    "service_file_name": "nubeio-wires-plat.service",
    "url_prefix": "",
    "service": "RUBIX_PLAT"
  },
  {
    "app_type": "PythonApp",
    "data_dir_name": "lora-raw",
    "description": "NubeIO LoRa Raw pyserial",
    "display_name": "LoRa Raw",
    "gateway_access": true,
    "min_support_version": "v1.1.0",
    "port": 1919,
    "repo_name": "lora-raw",
    "service_file_name": "nubeio-lora-raw.service",
    "url_prefix": "/lora",
    "service": "LORA_RAW"
  },
  {
    "app_type": "PythonApp",
    "data_dir_name": "bacnet-server",
    "description": "Flask Application for Nube BACNET SERVER",
    "display_name": "Rubix BACnet Server",
    "gateway_access": true,
    "min_support_version": "v1.3.0",
    "port": 1717,
    "repo_name": "rubix-bacnet-server",
    "service_file_name": "nubeio-bacnet-server.service",
    "url_prefix": "/bacnet",
    "service": "BACNET_SERVER"
  }
]
```
#### List services for systemd operation: `/api/system/service/`

Output example:
```json
[
  {
    "display_name": "LoRa WAN Server Service",
    "service": "LORAWAN"
  },
  {
    "display_name": "Mosquitto Service",
    "service": "MOSQUITTO"
  },
  {
    "display_name": "BBB IO Service",
    "service": "BBB"
  },
  {
    "display_name": "DRAC Server Service",
    "service": "DRAC"
  },
  {
    "display_name": "Rubix Point Server",
    "service": "POINT_SERVER"
  },
  {
    "display_name": "LoRa Raw",
    "service": "LORA_RAW"
  },
  {
    "display_name": "Rubix Wires",
    "service": "WIRES"
  },
  {
    "display_name": "Rubix BACnet Server",
    "service": "BACNET_SERVER"
  },
  {
    "display_name": "Rubix Plat",
    "service": "RUBIX_PLAT"
  }
]
```