### PR TITLE
Add latest_version field

### DIFF
--- a/src/system/resources/app/app.py
+++ b/src/system/resources/app/app.py
@@ -22,7 +22,8 @@ class AppResource(Resource):
         **service_fields,
         'name': fields.String,
         'created_at': fields.String,
-        'browser_download_url': fields.String
+        'browser_download_url': fields.String,
+        'latest_version': fields.String
     }
 
     @classmethod
@@ -48,9 +49,14 @@ class AppResource(Resource):
                 app = get_app_from_service(details['service'], details['version'])
                 app_setting = current_app.config[AppSetting.FLASK_KEY]
                 browser_download_url = {}
+                latest_version = None
                 try:
                     browser_download_url = app.get_download_link(app_setting.token, True)
                 except Exception as e:
                     logger.error(str(e))
-                return {**details, 'is_installed': True, **browser_download_url}
+                try:
+                    latest_version = app.get_latest_release(app_setting.token)
+                except Exception as e:
+                    logger.error(str(e))
+                return {**details, 'is_installed': True, **browser_download_url, 'latest_version': latest_version}
         return {**app.to_property_dict(), 'service': app.service(), 'is_installed': False}

--- a/src/system/resources/app/app.py
+++ b/src/system/resources/app/app.py
@@ -1,5 +1,5 @@
 from flask import current_app
-from flask_restful import Resource, abort, fields, marshal_with
+from flask_restful import Resource, abort, fields, marshal_with, reqparse, inputs
 from werkzeug.local import LocalProxy
 
 from src import AppSetting
@@ -20,8 +20,6 @@ class AppResource(Resource):
         'min_support_version': fields.String,
         'port': fields.Integer,
         **service_fields,
-        'name': fields.String,
-        'created_at': fields.String,
         'browser_download_url': fields.String,
         'latest_version': fields.String
     }
@@ -30,33 +28,41 @@ class AppResource(Resource):
     @marshal_with(fields)
     def get(cls):
         try:
-            return cls.get_installed_apps_stat()
+            parser = reqparse.RequestParser()
+            parser.add_argument('browser_download_url', type=inputs.boolean, default=False)
+            parser.add_argument('latest_version', type=inputs.boolean, default=False)
+            args = parser.parse_args()
+            browser_download_url = args['browser_download_url']
+            latest_version = args['latest_version']
+            return cls.get_installed_apps_stat(browser_download_url, latest_version)
         except Exception as e:
             abort(501, message=str(e))
 
     @classmethod
-    def get_installed_apps_stat(cls):
+    def get_installed_apps_stat(cls, browser_download_url, latest_version):
         installed_apps = []
         for installable_app in inheritors(InstallableApp):
-            installed_apps.append(cls.get_installed_app_stat(installable_app()))
+            installed_apps.append(cls.get_installed_app_stat(installable_app(),browser_download_url,latest_version))
         return installed_apps
 
     @classmethod
-    def get_installed_app_stat(cls, app: InstallableApp) -> dict:
+    def get_installed_app_stat(cls, app: InstallableApp, browser_download_url, latest_version) -> dict:
         if systemctl_installed(app.service_file_name):
             details: dict = get_installed_app_details(app)
             if details:
                 app = get_app_from_service(details['service'], details['version'])
                 app_setting = current_app.config[AppSetting.FLASK_KEY]
-                browser_download_url = {}
-                latest_version = None
-                try:
-                    browser_download_url = app.get_download_link(app_setting.token, True)
-                except Exception as e:
-                    logger.error(str(e))
-                try:
-                    latest_version = app.get_latest_release(app_setting.token)
-                except Exception as e:
-                    logger.error(str(e))
-                return {**details, 'is_installed': True, **browser_download_url, 'latest_version': latest_version}
+                __browser_download_url = {}
+                __latest_version = None
+                if browser_download_url:
+                    try:
+                        __browser_download_url = app.get_download_link(app_setting.token, True)
+                    except Exception as e:
+                        logger.error(str(e))
+                if latest_version:
+                    try:
+                        __latest_version = app.get_latest_release(app_setting.token)
+                    except Exception as e:
+                        logger.error(str(e))
+                return {**details, 'is_installed': True, **__browser_download_url, 'latest_version': __latest_version}
         return {**app.to_property_dict(), 'service': app.service(), 'is_installed': False}

--- a/src/system/resources/app/stats.py
+++ b/src/system/resources/app/stats.py
@@ -1,4 +1,4 @@
-from flask_restful import Resource, marshal_with, abort
+from flask_restful import Resource, marshal_with, abort, reqparse, inputs
 
 from src.system.apps.base.installable_app import InstallableApp
 from src.system.resources.app.app import AppResource
@@ -9,8 +9,14 @@ class AppStatsResource(Resource):
     @marshal_with(AppResource.fields)
     def get(cls, service):
         try:
+            parser = reqparse.RequestParser()
+            parser.add_argument('browser_download_url', type=inputs.boolean, default=False)
+            parser.add_argument('latest_version', type=inputs.boolean, default=False)
+            args = parser.parse_args()
+            browser_download_url = args['browser_download_url']
+            latest_version = args['latest_version']
             app: InstallableApp = InstallableApp.get_app(service, None)
-            return AppResource.get_installed_app_stat(app)
+            return AppResource.get_installed_app_stat(app, browser_download_url, latest_version)
         except ModuleNotFoundError as e:
             abort(404, message=str(e))
         except Exception as e:


### PR DESCRIPTION
### Summary
-  Added ```browser_download_url``` and ```latest_version``` filter in GET endpoint ```api/app```. Examples:
  ```
   - http://localhost:1616/api/app?browser_download_url=true&latest_version=true
   - http://localhost:1616/api/app?browser_download_url=true (By default latest_version=false)
   - http://localhost:1616/api/app?latest_version=true (By default browser_download_url=false)
   - http://localhost:1616/api/app (By default browser_download_url=false and  latest_version=false)
```
-  Added ```browser_download_url``` and  ```latest_version``` filter in GET endpoint ```api/app/stats/<service>```. 
  ```
   - http://localhost:1616/api/app/stats/<service>?browser_download_url=true&latest_version=true
   - http://localhost:1616/api/app/stats/<service>?browser_download_url=true (By default latest_version=false)
   - http://localhost:1616/api/app/stats/<service>?latest_version=true (By default browser_download_url=false)
   - http://localhost:1616/api/app/stats/<service> (By default browser_download_url=false and  latest_version=false)
```