### PR TITLE
Delete API for config, environment & logging file

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,9 +262,9 @@ curl -X GET http://localhost:1616/api/app/download_data  -H "Content-Type: appli
 
 > Examples:
 ```bash
-curl -X DELETE http://localhost:1616/api/app/config/config  -H "Content-Type: application/json" -d '{"service":"POINT_SERVER", "data":{"drivers":{"generic":false},"services":{"mqtt":true}}'
-curl -X DELETE http://localhost:1616/api/app/config/logging  -H "Content-Type: application/json" -d '{"service":"POINT_SERVER", "data":"[loggers]\nroot,werkzeug,gunicorn.error,gunicorn.access"}'
-curl -X DELETE http://localhost:1616/api/app/config/env  -H "Content-Type: application/json" -d '{"service":"WIRES"}, "data":"PORT=1313\nSECRET_KEY=__SECRET_KEY__"'
+curl -X PUT http://localhost:1616/api/app/config/config  -H "Content-Type: application/json" -d '{"service":"POINT_SERVER", "data":{"drivers":{"generic":false},"services":{"mqtt":true}}'
+curl -X PUT http://localhost:1616/api/app/config/logging  -H "Content-Type: application/json" -d '{"service":"POINT_SERVER", "data":"[loggers]\nroot,werkzeug,gunicorn.error,gunicorn.access"}'
+curl -X PUT http://localhost:1616/api/app/config/env  -H "Content-Type: application/json" -d '{"service":"WIRES"}, "data":"PORT=1313\nSECRET_KEY=__SECRET_KEY__"'
 ```
 
 ##### Delete config files

--- a/README.md
+++ b/README.md
@@ -247,6 +247,46 @@ curl -X GET http://localhost:1616/api/app/download_data  -H "Content-Type: appli
 curl -X GET http://localhost:1616/api/app/download_data  -H "Content-Type: application/json" -d '{"service":"RUBIX_PLAT"}' -o 'RUBIX_PLAT_DATA'
 ```
 
+##### Update config files
+
+> PUT: `/api/app/config/config`
+> 
+> PUT: `/api/app/config/logging`
+> 
+> PUT: `/api/app/config/env`
+
+> Body
+```json
+{"service": "<service>", "data": "<data>"}
+```
+
+> Examples:
+```bash
+curl -X DELETE http://localhost:1616/api/app/config/config  -H "Content-Type: application/json" -d '{"service":"POINT_SERVER", "data":{"drivers":{"generic":false},"services":{"mqtt":true}}'
+curl -X DELETE http://localhost:1616/api/app/config/logging  -H "Content-Type: application/json" -d '{"service":"POINT_SERVER", "data":"[loggers]\nroot,werkzeug,gunicorn.error,gunicorn.access"}'
+curl -X DELETE http://localhost:1616/api/app/config/env  -H "Content-Type: application/json" -d '{"service":"WIRES"}, "data":"PORT=1313\nSECRET_KEY=__SECRET_KEY__"'
+```
+
+##### Delete config files
+
+> DELETE: `/api/app/config/config` 
+> 
+> DELETE: `/api/app/config/logging` 
+> 
+> DELETE: `/api/app/config/env` 
+
+> Body
+```json
+{"service": "<service>"}
+```
+
+> Examples:
+```bash
+curl -X DELETE http://localhost:1616/api/app/config/config  -H "Content-Type: application/json" -d '{"service":"POINT_SERVER"'
+curl -X DELETE http://localhost:1616/api/app/config/logging  -H "Content-Type: application/json" -d '{"service":"POINT_SERVER"'
+curl -X DELETE http://localhost:1616/api/app/config/env  -H "Content-Type: application/json" -d '{"service":"WIRES"}'
+```
+
 ##### Edit config.json
 
 - Copy config details to location: `/data/<config_dir>/config.json` and restart service

--- a/src/routes.py
+++ b/src/routes.py
@@ -6,7 +6,7 @@ from src.system.networking.network import NetworkInfo, NetworkSetStaticIP, Netwo
     NetworkCheckPort
 from src.system.networking.ufw import UFWRuleList, UFWStatus, UFWEnable
 from src.system.resources.app.app import AppResource
-from src.system.resources.app.config import UpdateLoggingResource, UpdateConfigResource, UpdateEnvResource
+from src.system.resources.app.config import ConfigResource, LoggingResource, EnvResource
 from src.system.resources.app.control import ControlResource
 from src.system.resources.app.delete_data import DeleteDataResource
 from src.system.resources.app.download import DownloadResource
@@ -70,9 +70,9 @@ api_app.add_resource(InstallResource, '/install')
 api_app.add_resource(UnInstallResource, '/uninstall')
 api_app.add_resource(DeleteDataResource, '/delete_data')
 api_app.add_resource(DownloadDataResource, '/download_data')
-api_app.add_resource(UpdateConfigResource, '/update_config')
-api_app.add_resource(UpdateLoggingResource, '/update_logging')
-api_app.add_resource(UpdateEnvResource, '/update_env')
+api_app.add_resource(ConfigResource, '/config/config')
+api_app.add_resource(LoggingResource, '/config/logging')
+api_app.add_resource(EnvResource, '/config/env')
 
 # 4
 api_wires = Api(bp_wires)

--- a/src/system/apps/base/installable_app.py
+++ b/src/system/apps/base/installable_app.py
@@ -211,6 +211,9 @@ class InstallableApp(BaseModel, ABC):
             return True
         return False
 
+    def download_data(self):
+        return directory_zip_service(os.path.join(self.get_global_dir(), 'data'))
+
     def get_global_dir(self) -> str:
         setting = current_app.config[AppSetting.FLASK_KEY]
         return os.path.join(setting.root_dir, self.data_dir_name)

--- a/src/system/apps/base/installable_app.py
+++ b/src/system/apps/base/installable_app.py
@@ -15,7 +15,7 @@ from src.inheritors import inheritors
 from src.model import BaseModel
 from src.system.apps.enums.types import Types
 from src.system.utils.file import delete_existing_folder, download_unzip_service, is_dir_exist, upload_unzip_service, \
-    write_file, directory_zip_service
+    write_file, delete_file, directory_zip_service
 from src.system.utils.shell import execute_command
 
 logger = LocalProxy(lambda: current_app.logger)
@@ -156,6 +156,24 @@ class InstallableApp(BaseModel, ABC):
             return True
         return False
 
+    def delete_config_file(self) -> bool:
+        if self.app_type == Types.PYTHON_APP.value:
+            delete_file(os.path.join(self.get_global_dir(), 'config/config.json'))
+            return True
+        return False
+
+    def delete_logging_file(self) -> bool:
+        if self.app_type == Types.PYTHON_APP.value:
+            delete_file(os.path.join(self.get_global_dir(), 'config/logging.conf'))
+            return True
+        return False
+
+    def delete_env_file(self) -> bool:
+        if self.app_type == Types.FRONTEND_APP.value:
+            delete_file(os.path.join(self.get_global_dir(), 'config/.env'))
+            return True
+        return False
+
     def after_download_upload(self, name: str):
         # they are already wrapped on folder
         download_dir: str = self.get_download_dir()
@@ -192,9 +210,6 @@ class InstallableApp(BaseModel, ABC):
             logger.info('Successfully completed data backup...')
             return True
         return False
-
-    def download_data(self):
-        return directory_zip_service(os.path.join(self.get_global_dir(), 'data'))
 
     def get_global_dir(self) -> str:
         setting = current_app.config[AppSetting.FLASK_KEY]

--- a/src/system/resources/app/config.py
+++ b/src/system/resources/app/config.py
@@ -8,7 +8,7 @@ from src.system.resources.app.utils import get_app_from_service, get_installed_a
 from src.system.resources.fields import config_fields
 
 
-class UpdateConfigResource(RubixResource):
+class ConfigResource(RubixResource):
     @classmethod
     @marshal_with(config_fields)
     def put(cls):
@@ -26,8 +26,22 @@ class UpdateConfigResource(RubixResource):
         app_details = get_installed_app_details(app) or {}
         return {'service': service, 'update': update, **app_details}
 
+    @classmethod
+    @marshal_with(config_fields)
+    def delete(cls):
+        parser = reqparse.RequestParser()
+        parser.add_argument('service', type=str, required=True)
+        args = parser.parse_args()
+        service: str = args['service'].upper()
+        app: InstallableApp = get_app_from_service(service)
+        delete = app.delete_config_file()
+        if delete:
+            app.restart()
+        app_details = get_installed_app_details(app) or {}
+        return {'service': service, 'delete': delete, **app_details}
 
-class UpdateLoggingResource(RubixResource):
+
+class LoggingResource(RubixResource):
     @classmethod
     @marshal_with(config_fields)
     def put(cls):
@@ -38,14 +52,28 @@ class UpdateLoggingResource(RubixResource):
         service: str = args['service'].upper()
         data: str = args['data']
         app: InstallableApp = get_app_from_service(service)
-        update = app.update_config_file(data)
+        update = app.update_logging_file(data)
         if update:
             app.restart()
         app_details = get_installed_app_details(app) or {}
         return {'service': service, 'update': update, **app_details}
 
+    @classmethod
+    @marshal_with(config_fields)
+    def delete(cls):
+        parser = reqparse.RequestParser()
+        parser.add_argument('service', type=str, required=True)
+        args = parser.parse_args()
+        service: str = args['service'].upper()
+        app: InstallableApp = get_app_from_service(service)
+        delete = app.delete_logging_file()
+        if delete:
+            app.restart()
+        app_details = get_installed_app_details(app) or {}
+        return {'service': service, 'delete': delete, **app_details}
 
-class UpdateEnvResource(RubixResource):
+
+class EnvResource(RubixResource):
     @classmethod
     @marshal_with(config_fields)
     def put(cls):
@@ -61,3 +89,18 @@ class UpdateEnvResource(RubixResource):
             app.restart()
         app_details = get_installed_app_details(app) or {}
         return {'service': service, 'update': update, **app_details}
+
+    @classmethod
+    @marshal_with(config_fields)
+    def delete(cls):
+        parser = reqparse.RequestParser()
+        parser.add_argument('service', type=str, required=True)
+        args = parser.parse_args()
+        service: str = args['service'].upper()
+        app: InstallableApp = get_app_from_service(service)
+        delete = app.delete_env_file()
+        if delete:
+            app.restart()
+        app_details = get_installed_app_details(app) or {}
+        return {'service': service, 'delete': delete, **app_details}
+

--- a/src/system/resources/app/config.py
+++ b/src/system/resources/app/config.py
@@ -21,8 +21,6 @@ class ConfigResource(RubixResource):
         app: InstallableApp = get_app_from_service(service)
         json_data = json.dumps(data, indent=2)
         update = app.update_config_file(json_data)
-        if update:
-            app.restart()
         app_details = get_installed_app_details(app) or {}
         return {'service': service, 'update': update, **app_details}
 
@@ -35,8 +33,6 @@ class ConfigResource(RubixResource):
         service: str = args['service'].upper()
         app: InstallableApp = get_app_from_service(service)
         delete = app.delete_config_file()
-        if delete:
-            app.restart()
         app_details = get_installed_app_details(app) or {}
         return {'service': service, 'delete': delete, **app_details}
 
@@ -53,8 +49,6 @@ class LoggingResource(RubixResource):
         data: str = args['data']
         app: InstallableApp = get_app_from_service(service)
         update = app.update_logging_file(data)
-        if update:
-            app.restart()
         app_details = get_installed_app_details(app) or {}
         return {'service': service, 'update': update, **app_details}
 
@@ -67,8 +61,6 @@ class LoggingResource(RubixResource):
         service: str = args['service'].upper()
         app: InstallableApp = get_app_from_service(service)
         delete = app.delete_logging_file()
-        if delete:
-            app.restart()
         app_details = get_installed_app_details(app) or {}
         return {'service': service, 'delete': delete, **app_details}
 
@@ -85,8 +77,6 @@ class EnvResource(RubixResource):
         data: str = args['data']
         app: InstallableApp = get_app_from_service(service)
         update = app.update_env_file(data)
-        if update:
-            app.restart()
         app_details = get_installed_app_details(app) or {}
         return {'service': service, 'update': update, **app_details}
 
@@ -99,8 +89,6 @@ class EnvResource(RubixResource):
         service: str = args['service'].upper()
         app: InstallableApp = get_app_from_service(service)
         delete = app.delete_env_file()
-        if delete:
-            app.restart()
         app_details = get_installed_app_details(app) or {}
         return {'service': service, 'delete': delete, **app_details}
 


### PR DESCRIPTION
Resolves: #130 
### Summary:
- Added endpoints `api/app/config/config`, `api/app/config/logging`, `api/app/config/env` for put and delete. Examples:
  ```
  curl -x PUT http://localhost:1616/api/app/config/config -H “Content-Type: application/json” -d
     ‘{
          "service":<service>,
          "data":{
                  "drivers":{
                         "generic": false,
                         "modbus_rtu": true,
                         "modbus_tcp": false,
                         "bridge": true
                   },
                  "services": {
                        "mqtt": true,
                        "histories": false,
                        "cleaner": false,
                        "history_sync_influxdb": false,
                        "history_sync_postgres": false
                  }  
          }
      }’
   ```
  ```
  curl -x DELETE http://localhost:1616/api/app/config/config -H “Content-Type: application/json” -d
     ‘{
          "service":<service>
      }’
   ```
   ```
  curl -x PUT http://localhost:1515/api/app/config/logging -H “Content-Type: application/json” -d
     ‘{
          "service":<service>,
          "data":"[loggers]\nroot,werkzeug,gunicorn.error,gunicorn.access\n\n[logger_gunicorn.error]\nlevel=INFO\nhandlers=consoleHandler"
      }’
   ```
  ```
  curl -x DELETE  http://localhost:1515/api/app/config/logging -H “Content-Type: application/json” -d
     ‘{
          "service":<service>
      }’
   ```
   ```
  curl -x PUT http://localhost:1515/api/app/config/env -H “Content-Type: application/json” -d
     ‘{
          "service":<service>,
          "data":"PORT=1313\nSECRET_KEY=__SECRET_KEY__"
      }’
   ```
   ```
  curl -x DELETE http://localhost:1515/api/app/config/env -H “Content-Type: application/json” -d
     ‘{
          "service":<service>
      }’
   ```