### PR TITLE
Add OpenVPN Client app

### DIFF
--- a/config/apps.json
+++ b/config/apps.json
@@ -116,6 +116,20 @@
       "description": "Flow Framework",
       "gateway_access": true,
       "url_prefix": "ff"
+    },
+    {
+      "app_type": "AptApp",
+      "service": "OPEN_VPN_CLIENT",
+      "display_name": "Open VPN Client",
+      "repo_name": "openvpn",
+      "service_file_name": "openvpn@client",
+      "data_dir_name": "openvpn-client",
+      "port": 0,
+      "min_support_version": "v0.0.0",
+      "description": "Open VPN Client service",
+      "gateway_access": false,
+      "url_prefix": "",
+      "config_file": "/etc/openvpn/client.conf"
     }
   ]
 }

--- a/config/apps.master.json
+++ b/config/apps.master.json
@@ -129,6 +129,20 @@
       "description": "Flow Framework",
       "gateway_access": true,
       "url_prefix": "ff"
+    },
+    {
+      "app_type": "AptApp",
+      "service": "OPEN_VPN_CLIENT",
+      "display_name": "Open VPN Client",
+      "repo_name": "openvpn",
+      "service_file_name": "openvpn@client",
+      "data_dir_name": "openvpn-client",
+      "port": 0,
+      "min_support_version": "v0.0.0",
+      "description": "Open VPN Client service",
+      "gateway_access": false,
+      "url_prefix": "",
+      "config_file": "/etc/openvpn/client.conf"
     }
   ]
 }

--- a/src/setting.py
+++ b/src/setting.py
@@ -32,6 +32,7 @@ class InstallableAppSetting(BaseSetting):
         self.name_contains = ''
         self.systemd_static_wd_value = ''
         self.systemd_file_dir = ''
+        self.config_file = ''
 
 
 class AppSetting:

--- a/src/system/apps/base/__init__.py
+++ b/src/system/apps/base/__init__.py
@@ -1,5 +1,6 @@
-__all__ = ['frontend_app', 'python_app', 'go_app']
+__all__ = ['frontend_app', 'python_app', 'go_app', 'apt_app']
 
 from src.system.apps.base import frontend_app
 from src.system.apps.base import go_app
 from src.system.apps.base import python_app
+from src.system.apps.base import apt_app

--- a/src/system/apps/base/apt_app.py
+++ b/src/system/apps/base/apt_app.py
@@ -1,0 +1,40 @@
+from abc import ABC
+
+import gevent
+from flask import current_app
+from werkzeug.local import LocalProxy
+
+from src.system.apps.base.installable_app import InstallableApp
+from src.system.apps.enums.enums import Types
+from src.system.utils.shell import execute_command
+
+logger = LocalProxy(lambda: current_app.logger)
+
+
+class AptApp(InstallableApp, ABC):
+    @property
+    def app_type(self):
+        return Types.APT_APP.value
+
+    @property
+    def is_asset(self):
+        return False
+
+    def install(self) -> bool:
+        logger.info('Hitting apt-get update...')
+        execute_command('sudo apt-get update')
+        logger.info('Installing OpenVPN Service...')
+        if not execute_command('sudo apt-get install openvpn'):
+            return False
+        logger.info('Successfully installed OpenVPN service')
+        return True
+
+    def uninstall(self) -> bool:
+        logger.info('Stopping OpenVPN Service...')
+        if not execute_command('sudo systemctl disable openvpn@client && sudo systemctl stop openvpn@client'):
+            return False
+        logger.info('Removing OpenVPN service...')
+        if not execute_command('sudo apt-get remove openvpn'):
+            return False
+        logger.info('OpenVPN Service is deleted.')
+        return True

--- a/src/system/apps/enums/enums.py
+++ b/src/system/apps/enums/enums.py
@@ -7,6 +7,7 @@ class Types(enum.Enum):
     PYTHON_APP = 'PythonApp'
     GO_APP = 'GoApp'
     JAVA_APP = 'JavaApp'
+    APT_APP = 'AptApp'
 
 
 class DownloadState(enum.Enum):


### PR DESCRIPTION
Resolves: #217 
### Summary:
- Added OpenVPN Client app. Example
  ```
    }  
      "app_type": "AptApp",
      "service": "OPEN_VPN_CLIENT",
      "display_name": "Open VPN Client",
      "repo_name": "openvpn",
      "service_file_name": "openvpn@client",
      "data_dir_name": "openvpn-client",
      "port": 0,
      "min_support_version": "v0.0.0",
      "description": "Open VPN Client service",
      "gateway_access": false,
      "url_prefix": "",
      "config_file": "/etc/openvpn/client.conf"
    }
  ```
- Steps:
  - Download
     ```
     POST `/api/app/download`
     -d
     [
      {
         "service": "OPEN_VPN_CLIENT",
         "version": "v0.0.0"
       }
     ]
    ```
  - Install
    ```
     POST `/api/app/install`
     -d
     [
       {
         "service": "OPEN_VPN_CLIENT",
         "version": "v0.0.0"
       }
     ]
    ```
  - Update config
     ```
     PUT `/api/app/config/config`
     -d
     [
       {
         "service": "OPEN_VPN_CLIENT",
         "data": "dev tun"
       }
     ]
    ```
  - start|stop|enable|disable
     ```
     POST `/api/app/control`
     -d
     [
       {
         "service": "OPEN_VPN_CLIENT",
         "action": "start|stop|enable|disable"
       }
     ]
    ```