### PR TITLE
Create restart job

### DIFF
--- a/src/background.py
+++ b/src/background.py
@@ -39,6 +39,9 @@ class Background:
                 from src.discover.remote_device_registry import RemoteDeviceRegistry
                 gevent.spawn(RemoteDeviceRegistry().register, setting)
 
+        from src.system.services.restart_job import RestartJob
+        FlaskThread(target=RestartJob().setup, daemon=True).start()
+
     @staticmethod
     def sync_on_start():
         pass

--- a/src/routes.py
+++ b/src/routes.py
@@ -17,6 +17,7 @@ from src.system.resources.app.download import DownloadResource, DownloadStateRes
 from src.system.resources.app.download_data import DownloadDataResource
 from src.system.resources.app.install import InstallResource
 from src.system.resources.app.release import ReleaseResource
+from src.system.resources.app.restart_job import RestartJobResource
 from src.system.resources.app.stats import AppStatsResource
 from src.system.resources.app.token import TokenResource
 from src.system.resources.app.uninstall import UnInstallResource
@@ -26,6 +27,7 @@ from src.system.resources.host_reboot import HostReboot
 from src.system.resources.host_timezone import SetSystemTimeZone
 from src.system.resources.ping import Ping
 from src.system.resources.service.control import ServiceControl
+from src.system.resources.service.restart_job import ServiceRestartJob
 from src.system.resources.service.service import ServiceResource
 from src.system.resources.service.stats import ServiceStats
 from src.users.resource_login_users import UsersLoginResource
@@ -64,6 +66,7 @@ api_service = Api(bp_service)
 api_service.add_resource(ServiceResource, '')
 api_service.add_resource(ServiceStats, '/stats/<string:service>')
 api_service.add_resource(ServiceControl, "/control")
+api_service.add_resource(ServiceRestartJob, "/restart_job")
 
 # 4
 api_app = Api(bp_app)
@@ -83,7 +86,7 @@ api_app.add_resource(DownloadDataResource, '/download_data')
 api_app.add_resource(ConfigResource, '/config/config')
 api_app.add_resource(LoggingResource, '/config/logging')
 api_app.add_resource(EnvResource, '/config/env')
-
+api_app.add_resource(RestartJobResource, "/restart_job")
 # 5
 api_device_info = Api(bp_device_info)
 api_device_info.add_resource(DeviceInfoResource, '/plat')

--- a/src/setting.py
+++ b/src/setting.py
@@ -63,6 +63,7 @@ class AppSetting:
     default_users_file = 'users.txt'
     default_slaves_file = 'slaves.json'
     default_download_state_file = 'download_stat.json'
+    default_service_restart_job_file = 'service_restart_job.json'
 
     def __init__(self, **kwargs):
         self.__port = kwargs.get('port') or AppSetting.PORT
@@ -90,6 +91,7 @@ class AppSetting:
         self.__mqtt_rest_bridge_setting: MqttRestBridgeSetting = MqttRestBridgeSetting()
         self.__installable_app_settings: List[InstallableAppSetting] = [InstallableAppSetting()]
         self.__download_state_file = os.path.join(self.__data_dir, self.default_download_state_file)
+        self.__service_restart_job_file = os.path.join(self.__data_dir, self.default_service_restart_job_file)
 
     @property
     def port(self):
@@ -174,6 +176,10 @@ class AppSetting:
     @property
     def download_status_file(self) -> str:
         return self.__download_state_file
+
+    @property
+    def service_restart_job_file(self) -> str:
+        return self.__service_restart_job_file
 
     def reload(self, is_json_str: bool = False):
         data = self.__read_file(self.default_setting_file, self.__config_dir, is_json_str)

--- a/src/system/resources/app/app.py
+++ b/src/system/resources/app/app.py
@@ -12,6 +12,7 @@ from src.inheritors import get_instance
 from src.system.apps.base.installable_app import InstallableApp
 from src.system.resources.app.utils import get_installed_app_details, get_app_from_service, get_github_token
 from src.system.resources.fields import service_fields
+from src.system.resources.service.utils import get_service_restart_job
 from src.system.utils.shell import systemctl_installed
 
 logger = LocalProxy(lambda: current_app.logger)
@@ -31,7 +32,7 @@ class AppResource(RubixResource):
         'port': fields.Integer,
         **service_fields,
         'browser_download_url': fields.String,
-        'latest_version': fields.String
+        'latest_version': fields.String,
     }
 
     @classmethod
@@ -70,6 +71,7 @@ class AppResource(RubixResource):
                 latest_versions[output.get('service')] = output.get('latest_version')
         for installed_app in installed_apps:
             installed_app['latest_version'] = latest_versions.get(installed_app.get('service'))
+            installed_app['restart_job'] = get_service_restart_job(installed_app.get('service'))
         return installed_apps
 
     @classmethod

--- a/src/system/resources/app/restart_job.py
+++ b/src/system/resources/app/restart_job.py
@@ -1,0 +1,22 @@
+from rubix_http.exceptions.exception import NotFoundException
+
+from src.system.apps.base.installable_app import InstallableApp
+from src.system.resources.service.restart_job import ServiceRestartJob
+from src.system.resources.service.utils import create_service_cmd
+
+
+class RestartJobResource(ServiceRestartJob):
+    @classmethod
+    def validate_and_create_restart_service_cmd(cls, service: str) -> str:
+        try:
+            app: InstallableApp = InstallableApp.get_app(service, "")
+            return create_service_cmd("restart", app.service_file_name)
+        except ModuleNotFoundError:
+            raise NotFoundException(f'App service {service} does not exist in our system')
+
+    @classmethod
+    def validate_service(cls, service: str):
+        try:
+            InstallableApp.get_app(service, "")
+        except ModuleNotFoundError:
+            raise NotFoundException(f'App service {service} does not exist in our system')

--- a/src/system/resources/fields.py
+++ b/src/system/resources/fields.py
@@ -2,6 +2,11 @@ from flask_restful import fields
 
 from src.system.utils.shell import States
 
+restart_job_fields = {
+    "timer": fields.Integer,
+    "error": fields.String
+}
+
 service_fields = {
     'display_name': fields.String,
     'service': fields.String,
@@ -10,7 +15,8 @@ service_fields = {
     'status': fields.Boolean(default=False),
     'date_since': fields.String,
     'time_since': fields.String,
-    'is_enabled': fields.Boolean(default=False)
+    'is_enabled': fields.Boolean(default=False),
+    'restart_job': fields.Nested(restart_job_fields)
 }
 
 config_fields = {

--- a/src/system/resources/rest_schema/schema_restart_job.py
+++ b/src/system/resources/rest_schema/schema_restart_job.py
@@ -1,0 +1,17 @@
+restart_job_attributes = {
+    'service': {
+        'type': str,
+        'required': True
+    },
+    'timer': {
+        'type': int,
+        'required': True
+    }
+}
+
+restart_job_delete_attributes = {
+    'service': {
+        'type': str,
+        'required': True
+    }
+}

--- a/src/system/resources/service/restart_job.py
+++ b/src/system/resources/service/restart_job.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timedelta
+
+from flask import request
+from rubix_http.exceptions.exception import BadDataException, NotFoundException
+from rubix_http.resource import RubixResource
+
+from src.system.resources.rest_schema.schema_restart_job import restart_job_attributes, restart_job_delete_attributes
+from src.system.resources.service.utils import create_service_restart_job, Services, create_service_cmd, \
+    delete_service_restart_job
+from src.system.utils.data_validation import validate_args
+
+
+class ServiceRestartJob(RubixResource):
+    @classmethod
+    def post(cls):
+        args = request.get_json()
+        if not validate_args(args, restart_job_attributes):
+            raise BadDataException('Invalid request')
+        restart_res = []
+        for arg in args:
+            service: str = arg['service'].upper()
+            timer: int = arg['timer']
+            res = {'service': service, 'timer': timer, 'error': ''}
+            try:
+                cmd: str = cls.validate_and_create_restart_service_cmd(arg['service'].upper())
+                restart_job: dict = {
+                    service: {
+                        "timer": timer,
+                        "cmd": cmd,
+                        "prev_time": str(datetime.now()),
+                        "next_time": str(datetime.now() + timedelta(minutes=timer))
+                    }
+                }
+                create_service_restart_job(restart_job)
+            except Exception as e:
+                res = {**res, 'error': str(e)}
+            restart_res.append(res)
+        return restart_res
+
+    @classmethod
+    def delete(cls):
+        args = request.get_json()
+        if not validate_args(args, restart_job_delete_attributes):
+            raise BadDataException('Invalid request')
+        restart_res = []
+        for arg in args:
+            service: str = arg['service'].upper()
+            res = {'service': service, 'error': ''}
+            try:
+                cls.validate_service(service)
+                delete_service_restart_job(service)
+            except Exception as e:
+                res = {**res, 'error': str(e)}
+            restart_res.append(res)
+        return restart_res
+
+    @classmethod
+    def validate_and_create_restart_service_cmd(cls, service: str) -> str:
+        if service in Services.__members__.keys():
+            service_file_name = Services[service].value.get('service_file_name')
+            return create_service_cmd("restart", service_file_name)
+        raise NotFoundException(f'service {service} does not exist in our system')
+
+    @classmethod
+    def validate_service(cls, service: str):
+        if service not in Services.__members__.keys():
+            raise NotFoundException(f'service {service} does not exist in our system')

--- a/src/system/resources/service/service.py
+++ b/src/system/resources/service/service.py
@@ -2,7 +2,7 @@ from flask_restful import marshal_with
 from rubix_http.resource import RubixResource
 
 from src.system.resources.fields import service_fields
-from src.system.resources.service.utils import Services
+from src.system.resources.service.utils import Services, get_service_restart_job
 from src.system.utils.shell import systemctl_status, systemctl_installed
 
 
@@ -31,4 +31,5 @@ class ServiceResource(RubixResource):
             'display_name': Services[service].value.get('display_name'),
             'service': service,
             'is_installed': is_installed,
+            'restart_job': get_service_restart_job(service)
         }

--- a/src/system/services/restart_job.py
+++ b/src/system/services/restart_job.py
@@ -1,0 +1,39 @@
+import logging
+from datetime import datetime, timedelta
+
+import gevent
+
+from src import AppSetting
+from src.system.resources.service.utils import create_service_restart_job, get_service_restart_jobs
+from src.system.utils.shell import execute_command_with_exception
+
+logger = logging.getLogger(__name__)
+
+
+class RestartJob:
+    def setup(self):
+        while True:
+            gevent.sleep(60)
+            self.restart()
+
+    @classmethod
+    def restart(cls):
+        logger.info("Service restart has been called")
+        service_restart_jobs: dict = get_service_restart_jobs()
+        for key, restart_job in service_restart_jobs.items():
+            timer: int = restart_job.get("timer", 0)
+            cmd: str = restart_job.get("cmd", None)
+            next_time: str = restart_job.get("next_time", None)
+            time_check: bool = False if next_time is None else \
+                datetime.strptime(next_time, '%Y-%m-%d %H:%M:%S.%f') <= datetime.now()
+            if timer > 0 and cmd is not None and time_check:
+                try:
+                    execute_command_with_exception(cmd)
+                    restart_job = {**restart_job, "prev_time": str(datetime.now()),
+                                   "next_time": str(datetime.now() + timedelta(minutes=timer)), "error": ''}
+                except Exception as e:
+                    restart_job = {**restart_job, "next_time": str(datetime.now() + timedelta(minutes=timer)),
+                                   "error": str(e)}
+                    logger.error(str(e))
+                create_service_restart_job({key: restart_job})
+        logger.info("Service restart has been completed")


### PR DESCRIPTION
Resolves: #118
### Summary:
- Added `system/service/restart_job` and `app/restart_job` Examples:
   ```
     POST `/api/system/service/restart_job` or `/api/app/restart_job`
     -d
     [
      {
         "service": "POINT_SERVER",
         "timer": 30
       },
      {
         "service": "LORAWAN",
         "timer": 10
       }
     ]


     DELETE `/api/system/service/restart_job` or `/api/app/restart_job`
     -d
     [
      {
         "service": "POINT_SERVER"
       },
      {
         "service": "LORAWAN"
       }
     ]

    ```
- Added `restart_job` return fields in `/app`, `app/stats/<service>`, `system/service` and `system/service/stats/<service>`. Example:
  ```
     POST `/api/system/service/restart_job` or `/api/app/restart_job`
     -d
      {
         ....
         "restart_job": {
              "timer": <timer>,
              "error": <error>
          }
         ....
       }
    ```