### PR TITLE
Add API for app plugins

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -16,6 +16,8 @@ from src.system.resources.app.delete_data import DeleteDataResource
 from src.system.resources.app.download import DownloadResource, DownloadStateResource
 from src.system.resources.app.download_data import DownloadDataResource
 from src.system.resources.app.install import InstallResource
+from src.system.resources.app.plugin import DownloadPluginResource, \
+    InstallPluginResource, UnInstallPluginResource, PluginDownloadStateResource, PluginResource
 from src.system.resources.app.release import ReleaseResource
 from src.system.resources.app.restart_job import RestartJobResource
 from src.system.resources.app.stats import AppStatsResource
@@ -87,6 +89,11 @@ api_app.add_resource(ConfigResource, '/config/config')
 api_app.add_resource(LoggingResource, '/config/logging')
 api_app.add_resource(EnvResource, '/config/env')
 api_app.add_resource(RestartJobResource, "/restart_job")
+api_app.add_resource(PluginResource, '/plugins/<string:service>')
+api_app.add_resource(DownloadPluginResource, '/plugins/<string:service>/download')
+api_app.add_resource(PluginDownloadStateResource, '/plugins/download_state')
+api_app.add_resource(InstallPluginResource, '/plugins/<string:service>/install')
+api_app.add_resource(UnInstallPluginResource, '/plugins/<string:service>/uninstall')
 # 5
 api_device_info = Api(bp_device_info)
 api_device_info.add_resource(DeviceInfoResource, '/plat')

--- a/src/setting.py
+++ b/src/setting.py
@@ -65,6 +65,7 @@ class AppSetting:
     default_slaves_file = 'slaves.json'
     default_download_state_file = 'download_stat.json'
     default_service_restart_job_file = 'service_restart_job.json'
+    default_plugin_download_state_file = 'plugin_download_stat.json'
 
     def __init__(self, **kwargs):
         self.__port = kwargs.get('port') or AppSetting.PORT
@@ -92,6 +93,7 @@ class AppSetting:
         self.__mqtt_rest_bridge_setting: MqttRestBridgeSetting = MqttRestBridgeSetting()
         self.__installable_app_settings: List[InstallableAppSetting] = [InstallableAppSetting()]
         self.__download_state_file = os.path.join(self.__data_dir, self.default_download_state_file)
+        self.__plugin_download_state_file = os.path.join(self.__data_dir, self.default_plugin_download_state_file)
         self.__service_restart_job_file = os.path.join(self.__data_dir, self.default_service_restart_job_file)
 
     @property
@@ -177,6 +179,10 @@ class AppSetting:
     @property
     def download_status_file(self) -> str:
         return self.__download_state_file
+
+    @property
+    def plugin_download_status_file(self) -> str:
+        return self.__plugin_download_state_file
 
     @property
     def service_restart_job_file(self) -> str:

--- a/src/system/apps/base/go_app.py
+++ b/src/system/apps/base/go_app.py
@@ -1,16 +1,38 @@
+import json
+import os
+import shutil
 from abc import ABC
 
+import requests
 from flask import current_app
 from werkzeug.local import LocalProxy
 
+from src import AppSetting
 from src.pyinstaller import resource_path
 from src.system.apps.base.systemd_app import SystemdApp
 from src.system.apps.enums.enums import Types
+from src.system.utils.file import download_unzip_service, delete_file, delete_existing_folder
 
 logger = LocalProxy(lambda: current_app.logger)
 
 
+def select_plugin_download_link(plugin: str, row: any):
+    setting = current_app.config[AppSetting.FLASK_KEY]
+    for asset in row.get('assets', []):
+        artifact_name: str = asset.get('name')
+        if setting.device_type in artifact_name and plugin in artifact_name:
+            return asset.get('url')
+
+
+def get_plugin_file_name(plugin: str):
+    setting: AppSetting = current_app.config[AppSetting.FLASK_KEY]
+    return f'{plugin}-{setting.device_type}.so'
+
+
 class GoApp(SystemdApp, ABC):
+    def __init__(self):
+        super().__init__()
+
     @property
     def app_type(self):
         return Types.GO_APP.value
@@ -44,3 +66,117 @@ class GoApp(SystemdApp, ABC):
                     line = line.replace('<description>', self.description)
                 lines.append(line)
         return lines
+
+    def get_plugin_list(self, token: str):
+        headers = {}
+        if token:
+            headers['Authorization'] = f'Bearer {token}'
+        release_link: str = f'https://api.github.com/repos/NubeIO/{self.repo_name}/releases/tags/{self.version}'
+        resp = requests.get(release_link, headers=headers)
+        row: any = json.loads(resp.content)
+        return self._select_plugin_list(row)
+
+    def download_plugins(self, plugins: list) -> list:
+        download_res = []
+        delete_existing_folder(self.get_plugin_download_dir())
+        from src.system.resources.app.utils import get_github_token
+        token: str = get_github_token()
+        plugin_download_links = self._get_plugin_download_links(token, plugins)
+        for plugin_download_link in plugin_download_links:
+            plugin: str = plugin_download_link['plugin']
+            download_link: str = plugin_download_link['download_link']
+            error = plugin_download_link['error']
+            if error:
+                download_res.append({'plugin': plugin, 'download': False, 'error': error})
+            else:
+                try:
+                    download_unzip_service(download_link, self.get_plugin_download_dir(), token,
+                                           self.is_asset)
+                    download_res.append({'plugin': plugin, 'download': True, 'error': ""})
+                except Exception as e:
+                    download_res.append({'plugin': plugin, 'download': False, 'error': str(e)})
+        return download_res
+
+    def download_installed_plugin(self):
+        installed_path: str = self.get_plugin_installation_dir()
+        plugins = [x.split('-')[0] for x in os.listdir(installed_path)]
+        self.download_plugins(plugins)
+
+    def install_plugin(self, plugin) -> bool:
+        try:
+            mode = 0o744
+            plugin_file_name = get_plugin_file_name(plugin)
+            source_file = os.path.join(self.get_plugin_download_dir(), plugin_file_name)
+            destination: str = os.path.join(self.get_global_dir(), 'data', 'plugins')
+            destination_file: str = os.path.join(destination, plugin_file_name)
+            os.makedirs(destination, mode, True)
+            shutil.copy(source_file, destination_file)
+
+            destination = self.get_plugin_installation_dir()
+            destination_file = os.path.join(destination, plugin_file_name)
+            os.makedirs(destination, mode, True)
+            shutil.copy(source_file, destination_file)
+        except Exception as e:
+            logger.info(str(e))
+            return False
+        return True
+
+    def install_plugins(self) -> bool:
+        try:
+            if not os.path.exists(self.get_plugin_download_dir()):
+                return False
+            shutil.copytree(self.get_plugin_download_dir(), self.get_plugin_installation_dir())
+            destination = os.path.join(self.get_global_dir(), 'data', 'plugins')
+            delete_existing_folder(destination)
+            shutil.copytree(self.get_plugin_download_dir(), destination)
+        except Exception as e:
+            logger.info(str(e))
+            return False
+        return True
+
+    def uninstall_plugin(self, plugin) -> bool:
+        try:
+            plugin_file_name = get_plugin_file_name(plugin)
+            file: str = os.path.join(self.get_global_dir(), 'data', 'plugins', plugin_file_name)
+            delete_file(file)
+            file = os.path.join(self.get_plugin_installation_dir(), plugin_file_name)
+            delete_file(file)
+        except Exception as e:
+            logger.info(str(e))
+            return False
+        return True
+
+    def _get_plugin_download_links(self, token: str, plugins: list):
+        download_links = []
+        headers = {}
+        if token:
+            headers['Authorization'] = f'Bearer {token}'
+        release_link: str = f'https://api.github.com/repos/NubeIO/{self.repo_name}/releases/tags/{self.version}'
+        resp = requests.get(release_link, headers=headers)
+        row: any = json.loads(resp.content)
+        setting: AppSetting = current_app.config[AppSetting.FLASK_KEY]
+        for plugin in plugins:
+            download_link = select_plugin_download_link(plugin, row)
+            if not download_link:
+                error: str = f'No plugin {plugin} for type {setting.device_type} & version {self.version}, ' \
+                             f'check your token & repo'
+                download_links.append({'plugin': plugin, 'download_link': download_link, 'error': error})
+            download_links.append({'plugin': plugin, 'download_link': download_link, 'error': ''})
+        return download_links
+
+    def _select_plugin_list(self, row: any):
+        setting = current_app.config[AppSetting.FLASK_KEY]
+        plugins: list = []
+        for asset in row.get('assets', []):
+            artifact_name: str = asset.get('name')
+            if setting.device_type in artifact_name and (self.select_in_content not in artifact_name):
+                plugin = asset.get('name').split(f"-{row.get('tag_name')[1:]}", 1)[0]
+                plugin_file_name = get_plugin_file_name(plugin)
+                plugins.append({
+                    'version': row.get('tag_name'),
+                    'name': plugin,
+                    'is_installed': os.path.exists(os.path.join(self.get_plugin_installation_dir(),
+                                                                plugin_file_name)),
+                    'created_at': row.get('created_at')
+                })
+        return plugins

--- a/src/system/apps/base/installable_app.py
+++ b/src/system/apps/base/installable_app.py
@@ -149,7 +149,23 @@ class InstallableApp(BaseModel, ABC):
                                                self.is_asset)
         existing_app_deletion: bool = delete_existing_folder(self.get_downloaded_dir())
         self.after_download_upload(download_name)
+        self.download_installed_plugin()
         return {'service': self.service, 'version': self.version, 'existing_app_deletion': existing_app_deletion}
+
+    def download_plugins(self, plugins: list) -> list:
+        return []
+
+    def download_installed_plugin(self):
+        pass
+
+    def install_plugin(self, plugin) -> bool:
+        return False
+
+    def install_plugins(self) -> bool:
+        return False
+
+    def uninstall_plugin(self, plugin) -> bool:
+        return False
 
     def upload(self, file: FileStorage) -> dict:
         if self.app_type == Types.APT_APP.value:
@@ -157,6 +173,7 @@ class InstallableApp(BaseModel, ABC):
         upload_name = upload_unzip_service(file, self.get_download_dir())
         existing_app_deletion: bool = delete_existing_folder(self.get_downloaded_dir())
         self.after_download_upload(upload_name)
+        self.download_installed_plugin()
         return {'service': self.service, 'version': self.version, 'existing_app_deletion': existing_app_deletion}
 
     def update_config_file(self, data) -> bool:
@@ -291,6 +308,9 @@ class InstallableApp(BaseModel, ABC):
             raise NotFoundException('Latest release not found!')
         return latest_release
 
+    def get_plugin_list(self, token: str):
+        return []
+
     def get_cwd(self) -> str:
         """current working dir for script.bash execution"""
         return self.get_installed_dir()
@@ -323,6 +343,14 @@ class InstallableApp(BaseModel, ABC):
         if self.app_type == Types.APT_APP.value:
             return self.app_setting.min_support_version
         return get_extracted_dir(self.get_installation_dir()).split("/")[-1]
+
+    def get_plugin_download_dir(self) -> str:
+        setting = current_app.config[AppSetting.FLASK_KEY]
+        return os.path.join(setting.download_dir, self.repo_name, 'plugins')
+
+    def get_plugin_installation_dir(self) -> str:
+        setting = current_app.config[AppSetting.FLASK_KEY]
+        return os.path.join(setting.install_dir, self.repo_name, 'plugins')
 
     def set_version(self, _version):
         self.__version = _version

--- a/src/system/resources/app/plugin.py
+++ b/src/system/resources/app/plugin.py
@@ -1,0 +1,96 @@
+import gevent
+from flask import request, current_app
+from rubix_http.exceptions.exception import BadDataException, NotFoundException, PreConditionException
+from rubix_http.resource import RubixResource
+
+from src.system.apps.base.installable_app import InstallableApp
+from src.system.apps.enums.enums import DownloadState
+from src.system.resources.app.utils import get_github_token, download_plugins_async, get_app_from_service, \
+    get_plugin_download_state, update_plugin_download_state
+from src.system.resources.rest_schema.schema_download import download_plugin_attributes
+from src.system.resources.rest_schema.schema_install import install_plugin_attributes
+from src.system.utils.data_validation import validate_args
+
+
+class PluginResource(RubixResource):
+    @classmethod
+    def get(cls, service):
+        token: str = get_github_token()
+        app: InstallableApp = get_app_from_service(service)
+        _version: str = app.get_installed_version()
+        if not _version:
+            return {"message": f"Please install service {service} first"}
+        app.set_version(_version)
+        return app.get_plugin_list(token)
+
+
+class DownloadPluginResource(RubixResource):
+    @classmethod
+    def post(cls, service):
+        args = request.get_json()
+        if not validate_args(args, download_plugin_attributes):
+            raise BadDataException('Invalid request')
+        download_state: str = get_plugin_download_state().get('state')
+        if download_state == DownloadState.DOWNLOADING.name:
+            raise PreConditionException('Download is in progress')
+        elif download_state == DownloadState.DOWNLOADED.name:
+            raise PreConditionException('Download state is not cleared')
+        app: InstallableApp = get_app_from_service(service.upper())
+        _version: str = app.get_installed_version()
+        if not _version:
+            return {"message": f"Please install service {service} first"}
+        app.set_version(_version)
+        update_plugin_download_state(DownloadState.DOWNLOADING)
+        gevent.spawn(download_plugins_async, current_app._get_current_object().app_context, app, args)
+        return {"message": "Download started"}
+
+
+class PluginDownloadStateResource(RubixResource):
+
+    @classmethod
+    def get(cls):
+        return get_plugin_download_state()
+
+    @classmethod
+    def delete(cls):
+        update_plugin_download_state(DownloadState.CLEARED)
+        return {'message': 'Download state is cleared'}
+
+
+class InstallPluginResource(RubixResource):
+    @classmethod
+    def post(cls, service):
+        args = request.get_json()
+        if not validate_args(args, install_plugin_attributes):
+            raise BadDataException('Invalid request')
+        install_res = []
+        try:
+            app: InstallableApp = get_app_from_service(service)
+            _version: str = app.get_installed_version()
+            if not _version:
+                return {"message": f"Please install service {service} first"}
+            for arg in args:
+                plugin: str = arg["plugin"].lower()
+                installation = app.install_plugin(plugin)
+                install_res.append({'plugin': plugin, 'installation': installation, 'error': ''})
+        except (Exception, NotFoundException) as e:
+            raise NotFoundException(str(e))
+        return install_res
+
+
+class UnInstallPluginResource(RubixResource):
+    @classmethod
+    def post(cls, service):
+        args = request.get_json()
+        if not validate_args(args, install_plugin_attributes):
+            raise BadDataException('Invalid request')
+        uninstall_res = []
+        try:
+            app: InstallableApp = get_app_from_service(service)
+            for arg in args:
+                plugin: str = arg["plugin"].lower()
+                installation = app.uninstall_plugin(plugin)
+                uninstall_res.append({'plugin': plugin, 'uninstall': installation, 'error': ''})
+        except (Exception, NotFoundException) as e:
+            raise NotFoundException(str(e))
+        return uninstall_res

--- a/src/system/resources/rest_schema/schema_download.py
+++ b/src/system/resources/rest_schema/schema_download.py
@@ -8,3 +8,10 @@ download_attributes = {
         'required': True
     }
 }
+
+download_plugin_attributes = {
+    'plugin': {
+        'type': str,
+        'required': True
+    },
+}

--- a/src/system/resources/rest_schema/schema_install.py
+++ b/src/system/resources/rest_schema/schema_install.py
@@ -8,3 +8,10 @@ install_attributes = {
         'required': True
     }
 }
+
+install_plugin_attributes = {
+    'plugin': {
+        'type': str,
+        'required': True
+    }
+}


### PR DESCRIPTION
Resolves: #215 
### Summary:
- Added API endpoints:
  - GET `api/app/plugins/<service>`
  - POST `api/app/plugins/<service>/download`
     ```
      -d [
            {
                "plugin": <plugin>
            }
      ]
     ```
  - GET/DELETE `api/app/plugins/download_state`
  - POST `api/app/plugins/<service>/install`
     ```
      -d [
            {
                "plugin": <plugin>
            }
      ]
     ```
  - POST `api/app/plugins/<service>/uninstall`
     ```
      -d [
            {
                "plugin": <plugin>
            }
      ]
     ```
 - Auto updates plugins on app upgrade(download and install).