### PR TITLE
Rename plugins download state API endpoint

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -91,7 +91,7 @@ api_app.add_resource(EnvResource, '/config/env')
 api_app.add_resource(RestartJobResource, "/restart_job")
 api_app.add_resource(PluginResource, '/plugins/<string:service>')
 api_app.add_resource(DownloadPluginResource, '/plugins/<string:service>/download')
-api_app.add_resource(PluginDownloadStateResource, '/plugins/download_state')
+api_app.add_resource(PluginDownloadStateResource, '/plugins/<string:service>/download_state')
 api_app.add_resource(InstallPluginResource, '/plugins/<string:service>/install')
 api_app.add_resource(UnInstallPluginResource, '/plugins/<string:service>/uninstall')
 # 5

--- a/src/system/resources/app/utils.py
+++ b/src/system/resources/app/utils.py
@@ -110,12 +110,13 @@ def update_download_state(state: DownloadState, services: List[Dict] = None):
                json.dumps({"state": state.name, "services": services if services else []}))
 
 
-def update_plugin_download_state(state: DownloadState, service: str = "", _version: str = "",
+def update_plugin_download_state(state: DownloadState, service: str, _version: str = "",
                                  plugins: List[Dict] = None):
     app_setting = current_app.config[AppSetting.FLASK_KEY]
+    plugin_download_state = json.loads(read_file(app_setting.plugin_download_status_file) or "{}")
     write_file(app_setting.plugin_download_status_file,
-               json.dumps({"state": state.name, "service": service, "version": _version,
-                           "plugins": plugins if plugins else []}))
+               json.dumps({**plugin_download_state,
+                           service: {"state": state.name, "version": _version, "plugins": plugins if plugins else []}}))
 
 
 def get_download_state():
@@ -124,10 +125,11 @@ def get_download_state():
         "state": DownloadState.CLEARED.name, "services": []}
 
 
-def get_plugin_download_state():
+def get_plugin_download_state(service: str):
     app_setting = current_app.config[AppSetting.FLASK_KEY]
-    return json.loads(read_file(app_setting.plugin_download_status_file) or "{}") or {
-        "state": DownloadState.CLEARED.name, "service": "", "version": "", "plugins": []}
+    plugin_download_state = json.loads(read_file(app_setting.plugin_download_status_file) or "{}")
+    return plugin_download_state.get(service, {}) or {
+        "state": DownloadState.CLEARED.name, "version": "", "plugins": []}
 
 
 def get_github_token() -> str:


### PR DESCRIPTION
### Summary
- Renamed `/api/app/plugins/download_state` to `/api/app/plugins/<string:service>/download_state`. Example:
  ```
  GET/DELETE `/api/app/plugins/FLOW_FRAMEWORK/download_state`
  ```