### PR TITLE
Add comment and tags endpoint

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -5,7 +5,7 @@ from src.discover.resources.remote_device import RemoteDevice
 from src.mrb_listener.resource_mrb_listener import MRBListenerResource
 from src.platform.resource_device_info import DeviceInfoResource
 from src.slaves.resources.slaves_plural import SlavesPlural
-from src.slaves.resources.slaves_singular import SlavesSingular
+from src.slaves.resources.slaves_singular import SlavesSingular, SlavesComment, SlavesTags
 from src.system.networking.network import NetworkInfo, NetworkSetStaticIP, NetworkSetDHCP, NetworkPingRange, \
     NetworkCheckPort
 from src.system.networking.ufw import UFWRuleList, UFWStatus, UFWEnable
@@ -118,3 +118,5 @@ bp_slaves = Blueprint('slaves', __name__, url_prefix='/api/slaves')
 api_slaves = Api(bp_slaves)
 api_slaves.add_resource(SlavesPlural, '')
 api_slaves.add_resource(SlavesSingular, '/<string:global_uuid>')
+api_slaves.add_resource(SlavesComment, '/comment/<string:global_uuid>')
+api_slaves.add_resource(SlavesTags, '/tags/<string:global_uuid>')

--- a/src/slaves/resources/slaves_base.py
+++ b/src/slaves/resources/slaves_base.py
@@ -3,10 +3,11 @@ import os
 from typing import Dict
 
 from flask import current_app
+from rubix_http.exceptions.exception import NotFoundException
 from rubix_http.resource import RubixResource
 
 from src import AppSetting
-from src.system.utils.file import read_file
+from src.system.utils.file import read_file, write_file
 
 
 class SlavesBase(RubixResource):
@@ -22,3 +23,21 @@ class SlavesBase(RubixResource):
         slaves_file = os.path.join(data_dir, AppSetting.default_slaves_file)
         slaves: Dict[str, Dict] = json.loads(read_file(slaves_file) or "{}")
         return slaves, slaves_file
+
+    @classmethod
+    def update_slave_comment(cls, global_uuid: str, comment: str):
+        slaves, slaves_file = cls.get_slaves()
+        if global_uuid not in slaves:
+            raise NotFoundException(f"global_uuid = {global_uuid} does not exist")
+        slave = {**slaves[global_uuid], "comment": comment}
+        write_file(slaves_file, json.dumps({**slaves, global_uuid: slave}))
+        return {global_uuid: {**slaves[global_uuid], "comment": comment}}
+
+    @classmethod
+    def update_slave_tags(cls, global_uuid: str, tags: list):
+        slaves, slaves_file = cls.get_slaves()
+        if global_uuid not in slaves:
+            raise NotFoundException(f"global_uuid = {global_uuid} does not exist")
+        slave = {**slaves[global_uuid], "tags": tags}
+        write_file(slaves_file, json.dumps({**slaves, global_uuid: slave}))
+        return {global_uuid: {**slaves[global_uuid], "tags": tags}}

--- a/src/slaves/resources/slaves_singular.py
+++ b/src/slaves/resources/slaves_singular.py
@@ -1,6 +1,8 @@
 import json
 
-from rubix_http.exceptions.exception import NotFoundException
+from flask import request
+from flask_restful import reqparse
+from rubix_http.exceptions.exception import NotFoundException, BadDataException
 
 from src.slaves.resources.slaves_base import SlavesBase
 from src.system.utils.file import write_file
@@ -16,3 +18,35 @@ class SlavesSingular(SlavesBase):
         del slaves[global_uuid]
         write_file(slaves_file, json.dumps(slaves))
         return slaves
+
+
+class SlavesComment(SlavesBase):
+
+    @classmethod
+    def put(cls, global_uuid):
+        parser = reqparse.RequestParser()
+        parser.add_argument('comment', type=str, required=True, store_missing=False)
+        data = parser.parse_args()
+        comment = data.get("comment")
+        return cls.update_slave_comment(global_uuid, comment)
+
+    @classmethod
+    def delete(cls, global_uuid):
+        cls.update_slave_comment(global_uuid, "")
+        return '', 204
+
+
+class SlavesTags(SlavesBase):
+
+    @classmethod
+    def put(cls, global_uuid):
+        args = request.get_json()
+        tags = args.get("tags")
+        if not isinstance(tags, list):
+            raise BadDataException('Invalid request')
+        return cls.update_slave_tags(global_uuid, tags)
+
+    @classmethod
+    def delete(cls, global_uuid):
+        cls.update_slave_tags(global_uuid, [])
+        return '', 204


### PR DESCRIPTION
Resolves: #975
### Summary:
- Add `slaves/comment` and `slaves/tags` endpoints. Examples:
  - DELETE `api/slaves/comment/<global_uuid>`
  - PUT `api/slaves/comment/<global_uuid>`
     ```
      -d [
            {
                "comment": "Comment"
            }
      ]
     ```
  - DELETE `api/slaves/tags/<global_uuid>` -> Clears tags
  - PUT `api/slaves/tags/<global_uuid>`
     ```
      -d [
            {
                "tags": ["t1","t1"]
            }
      ]
     ```