### PR TITLE
Fix: auto reboot

### DIFF
--- a/src/platform/resource_device_info.py
+++ b/src/platform/resource_device_info.py
@@ -6,9 +6,7 @@ from registry.resources.resource_device_info import get_device_info, put_device_
 from rubix_http.exceptions.exception import NotFoundException
 from rubix_http.resource import RubixResource
 
-from src.platform.schema_device_info import device_info_all_attributes, device_info_all_fields, \
-    device_info_all_fields_with_reboot_job
-from src.system.resources.service.utils import get_reboot_job
+from src.platform.schema_device_info import device_info_all_attributes, device_info_all_fields
 
 
 class DeviceInfoResource(RubixResource):
@@ -21,12 +19,12 @@ class DeviceInfoResource(RubixResource):
                             store_missing=False)
 
     @classmethod
-    @marshal_with(device_info_all_fields_with_reboot_job)
+    @marshal_with(device_info_all_fields)
     def get(cls):
         device_info: dict = get_device_info_dict()
         if not device_info:
             raise NotFoundException('Device info not found')
-        return {**device_info, 'reboot_job': get_reboot_job()}
+        return device_info
 
     @classmethod
     @marshal_with(device_info_all_fields)

--- a/src/platform/schema_device_info.py
+++ b/src/platform/schema_device_info.py
@@ -1,7 +1,4 @@
-from flask_restful import fields
-
 from src.platform.utils import map_rest_schema
-from src.system.resources.rest_schema.schema_reboot_job import reboot_all_fields
 
 device_info_all_attributes = {
     'client_id': {
@@ -81,5 +78,3 @@ device_info_return_attributes = {
 device_info_all_fields = {}
 map_rest_schema(device_info_return_attributes, device_info_all_fields)
 map_rest_schema(device_info_all_attributes, device_info_all_fields)
-
-device_info_all_fields_with_reboot_job = {**device_info_all_fields, 'reboot_job': fields.Nested(reboot_all_fields)}

--- a/src/proxy/reverse_proxy_routes.py
+++ b/src/proxy/reverse_proxy_routes.py
@@ -1,8 +1,10 @@
+import json
 from typing import Union
 
 import requests
 from flask import request, Response, Blueprint, current_app
 from flask_restful import abort
+from mrb.message import HttpMethod
 from registry.models.model_bios_info import BiosInfoModel
 from registry.resources.resource_bios_info import get_bios_info
 from requests.exceptions import ConnectionError
@@ -10,10 +12,13 @@ from requests.exceptions import ConnectionError
 from src import AppSetting
 from src.inheritors import get_instance
 from src.system.apps.base.installable_app import InstallableApp
+from src.system.resources.service.utils import get_reboot_job
 from src.token import get_internal_token
 
 bp_reverse_proxy = Blueprint("reverse_proxy", __name__, url_prefix='/')
 methods = ['GET', 'POST', 'PATCH', 'PUT', 'DELETE']
+
+BIOS_SERVICE_URL = 'api/service?'
 
 
 @bp_reverse_proxy.route("/<path:_>", methods=methods)
@@ -47,7 +52,17 @@ def reverse_proxy_handler(_):
     try:
         resp = requests.request(request.method, actual_url, json=request.get_json(),
                                 headers={**request.headers, 'Authorization': f"Internal {internal_token}"})
-        response = Response(resp.content, resp.status_code, resp.raw.headers.items())
+        # we are not upgrading BIOS, and we are changing data on the middleware (not so cool)
+        if path.startswith(BIOS_SERVICE_URL) and HttpMethod[request.method.upper()] == HttpMethod.GET:
+            reboot_job = get_reboot_job()
+            bios_service = json.loads(resp.content)
+            bios_service = {**bios_service, 'reboot_job': {
+                'timer': reboot_job.get('timer', 0),
+                'error': reboot_job.get('error', '')
+            }}
+            response = Response(json.dumps(bios_service, indent=4), resp.status_code, resp.raw.headers.items())
+        else:
+            response = Response(resp.content, resp.status_code, resp.raw.headers.items())
         return response
     except ConnectionError:
         abort(404)

--- a/src/proxy/slaves_multicast_proxy_routes.py
+++ b/src/proxy/slaves_multicast_proxy_routes.py
@@ -7,12 +7,9 @@ from mrb.mapper import api_to_slaves_multicast_topic_mapper
 from mrb.message import Response as MessageResponse, HttpMethod
 
 from src.discover.remote_device_registry import RemoteDeviceRegistry
-from src.system.resources.service.utils import get_reboot_job
 
 bp_slaves_multicast_proxy = Blueprint("slaves_multicast_proxy", __name__, url_prefix='/slaves/multicast')
 methods = ['GET']
-
-BIOS_SERVICE_URL = 'bios/api/service?'
 
 
 @bp_slaves_multicast_proxy.route("/<path:_>", methods=methods)
@@ -42,11 +39,5 @@ def slaves_proxy_handler(_):
         if response.error:
             return Response(json.dumps({'message': response.error_message}), response.status_code, response.headers)
         else:
-            if url == BIOS_SERVICE_URL and HttpMethod[request.method.upper()] == HttpMethod.GET:
-                reboot_job = get_reboot_job()
-                response.content = {**response.content, 'reboot_job': {
-                    'timer': reboot_job.get('timer', 0),
-                    'error': reboot_job.get('error', '')
-                }}
             return Response(json.dumps(response.content).encode('utf-8'), response.status_code, response.headers)
     return {"message": "Registered devices are not available or haven't registered yet!"}, 404

--- a/src/proxy/slaves_multicast_proxy_routes.py
+++ b/src/proxy/slaves_multicast_proxy_routes.py
@@ -7,9 +7,12 @@ from mrb.mapper import api_to_slaves_multicast_topic_mapper
 from mrb.message import Response as MessageResponse, HttpMethod
 
 from src.discover.remote_device_registry import RemoteDeviceRegistry
+from src.system.resources.service.utils import get_reboot_job
 
 bp_slaves_multicast_proxy = Blueprint("slaves_multicast_proxy", __name__, url_prefix='/slaves/multicast')
 methods = ['GET']
+
+BIOS_SERVICE_URL = 'bios/api/service?'
 
 
 @bp_slaves_multicast_proxy.route("/<path:_>", methods=methods)
@@ -39,5 +42,11 @@ def slaves_proxy_handler(_):
         if response.error:
             return Response(json.dumps({'message': response.error_message}), response.status_code, response.headers)
         else:
+            if url == BIOS_SERVICE_URL and HttpMethod[request.method.upper()] == HttpMethod.GET:
+                reboot_job = get_reboot_job()
+                response.content = {**response.content, 'reboot_job': {
+                    'timer': reboot_job.get('timer', 0),
+                    'error': reboot_job.get('error', '')
+                }}
             return Response(json.dumps(response.content).encode('utf-8'), response.status_code, response.headers)
     return {"message": "Registered devices are not available or haven't registered yet!"}, 404


### PR DESCRIPTION
### Summary
- Removed `reboot_job` form GET `api/wires/plat`
- Added `reboot_job` to GET `slaves/multicast/bios/api/service`. Example:
  ```
  {
     .....,
     "reboot_job": {
        "timer": 60,
        "error": ""
    }
  } 
  ```